### PR TITLE
Use local cache to upload source distribution

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -117,7 +117,7 @@ on:
         type: string
         default: ""
       upload_distribution:
-        description: "This inputs no longer has any effect. The built source distribution will always be uploaded to the local cache."
+        description: "This input no longer has any effect. The built source distribution will always be uploaded to the local cache."
         required: false
         type: boolean
         default: true

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -117,7 +117,7 @@ on:
         type: string
         default: ""
       upload_distribution:
-        description: "Whether or not to upload the built distribution as an artifact. **Note**: This is only relevant if 'python_package' is 'true', which is the default."
+        description: "This inputs no longer has any effect. The built source distribution will always be uploaded to the local cache."
         required: false
         type: boolean
         default: true
@@ -176,14 +176,26 @@ on:
         description: "A personal access token (PAT) with rights to update the `release_branch`. This will fallback on `GITHUB_TOKEN`."
         required: false
 
+    outputs:
+      cache-key:
+        description: "The cache key used for the local cache, where the source distribution may be found."
+        value: ${{ jobs.update-and-publish.outputs.cache-key }}
+
 jobs:
   update-and-publish:
     name: Update CHANGELOG and version and publish to PyPI
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ inputs.runner }}
 
+    permissions:
+      contents: write
+
+    outputs:
+      cache-key: ${{ steps.validate.outputs.cache-key }}
+
     steps:
     - name: Validate inputs
+      id: validate
       run: |
         if [[ ! "${{ inputs.python_version_build }}" =~ ^3\.([8-9]|1[0-4])(\..*)?$ ]]; then
           echo "Python version '${{ inputs.python_version_build }}' is not supported."
@@ -191,10 +203,31 @@ jobs:
           exit 1
         fi
 
+        if [ "${{ inputs.upload_distribution }}" == "false" ]; then
+          ::warning title=DeprecatedInput,file=.github/workflows/cd_release.yml::The 'upload_distribution' input is no longer used. The built source distribution will always be uploaded to the local cache.
+        fi
+
+        echo "cache-key=${{ github.repository }}-release-${{ github.sha }}" >> $GITHUB_OUTPUT
+
     - name: Checkout ${{ github.repository }}
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+
+    - name: Setup local cache
+      uses: tespkg/actions-cache@v1.9.0
+      with:
+        endpoint: ${{ secrets.CACHE_ENDPOINT }}
+        port: 9000
+        bucket: actions-cache
+        insecure: true
+        accessKey: ${{ secrets.CACHE_ACCESS_KEY }}
+        secretKey: ${{ secrets.CACHE_SECRET_KEY }}
+        region: 'us-east-1'
+        use-fallback: false
+        path: ${{ inputs.build_dir }}
+        key: ${{ github.repository }}-release-${{ github.sha }}
 
     - name: Set up Python ${{ inputs.python_version_build }}
       uses: actions/setup-python@v5
@@ -323,15 +356,17 @@ jobs:
         ${{ inputs.build_cmd }}
 
     - name: Update '${{ inputs.release_branch }}'
-      uses: CasperWA/push-protected@v2
-      with:
-        token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
-        branch: ${{ inputs.release_branch }}
-        pre_sleep: 15
-        force: true
-        tags: true
-        unprotect_reviews: true
-        debug: ${{ inputs.test }}
+      run: |
+        git checkout -b temp_release_branch
+        if [ $(git status --porcelain | wc -l) -ne 0 ]; then
+          echo "There are uncommitted changes in the repository. At this state, this is quite unexpected."
+          exit 1
+        fi
+        git checkout "${{ inputs.release_branch }}"
+        git merge --ff-only temp_release_branch
+        git push --force
+        git push --tags --force
+        git branch -D temp_release_branch
 
     - name: Get tagged versions
       id: tagged_versions
@@ -362,14 +397,20 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 
-    - name: Upload source distribution
-      if: inputs.upload_distribution && inputs.python_package
-      uses: actions/upload-artifact@v4
-      with:
-        name: dist
-        path: ${{ inputs.build_dir }}
-        if-no-files-found: error
-        overwrite: true
+    - name: Validate source distribution
+      if: inputs.python_package
+      run: |
+        # Error if the build directory does not exist
+        if [ ! -d "${{ inputs.build_dir }}" ]; then
+          echo "The distribution directory '${{ inputs.build_dir }}' does not exist."
+          exit 1
+        fi
+
+        # Error if the build directory is empty
+        if [ -z "$(ls -A "${{ inputs.build_dir }}")" ]; then
+          echo "The distribution directory '${{ inputs.build_dir }}' is empty."
+          exit 1
+        fi
 
     - name: Publish package to TestPyPI
       if: inputs.test && inputs.publish_on_pypi && inputs.python_package

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -358,7 +358,7 @@ jobs:
     - name: Update '${{ inputs.release_branch }}'
       run: |
         git checkout -b temp_release_branch
-        if [ $(git status --porcelain | wc -l) -ne 0 ]; then
+        if [ "$(git status --porcelain | wc -l)" -ne 0 ]; then
           echo "There are uncommitted changes in the repository. At this state, this is quite unexpected."
           exit 1
         fi

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -117,7 +117,7 @@ on:
         type: string
         default: ""
       upload_distribution:
-        description: "This input no longer has any effect. The built source distribution will always be uploaded to the local cache."
+        description: "Whether or not to upload the built distribution to the local cache. **Note**: This is only relevant if 'python_package' is 'true', which is the default."
         required: false
         type: boolean
         default: true
@@ -175,6 +175,15 @@ on:
       PAT:
         description: "A personal access token (PAT) with rights to update the `release_branch`. This will fallback on `GITHUB_TOKEN`."
         required: false
+      CACHE_ENDPOINT:
+        description: "The endpoint for the local cache. This is used to upload the built distribution."
+        required: false
+      CACHE_ACCESS_KEY:
+        description: "The access key for the local cache. This is used to upload the built distribution."
+        required: false
+      CACHE_SECRET_KEY:
+        description: "The secret key for the local cache. This is used to upload the built distribution."
+        required: false
 
     outputs:
       cache-key:
@@ -203,10 +212,6 @@ jobs:
           exit 1
         fi
 
-        if [ "${{ inputs.upload_distribution }}" == "false" ]; then
-          ::warning title=DeprecatedInput,file=.github/workflows/cd_release.yml::The 'upload_distribution' input is no longer used. The built source distribution will always be uploaded to the local cache.
-        fi
-
         echo "cache-key=${{ github.repository }}-release-${{ github.sha }}" >> $GITHUB_OUTPUT
 
     - name: Checkout ${{ github.repository }}
@@ -214,20 +219,6 @@ jobs:
       with:
         fetch-depth: 0
         token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
-
-    - name: Setup local cache
-      uses: tespkg/actions-cache@v1.9.0
-      with:
-        endpoint: ${{ secrets.CACHE_ENDPOINT }}
-        port: 9000
-        bucket: actions-cache
-        insecure: true
-        accessKey: ${{ secrets.CACHE_ACCESS_KEY }}
-        secretKey: ${{ secrets.CACHE_SECRET_KEY }}
-        region: 'us-east-1'
-        use-fallback: false
-        path: ${{ inputs.build_dir }}
-        key: ${{ github.repository }}-release-${{ github.sha }}
 
     - name: Set up Python ${{ inputs.python_version_build }}
       uses: actions/setup-python@v5
@@ -398,7 +389,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 
     - name: Validate source distribution
-      if: inputs.python_package
+      if: inputs.upload_distribution && inputs.python_package
       run: |
         # Error if the build directory does not exist
         if [ ! -d "${{ inputs.build_dir }}" ]; then
@@ -411,6 +402,21 @@ jobs:
           echo "The distribution directory '${{ inputs.build_dir }}' is empty."
           exit 1
         fi
+
+    - name: Upload source distribution
+      if: inputs.upload_distribution && inputs.python_package
+      uses: tespkg/actions-cache/save@v1.9.0
+      with:
+        endpoint: ${{ secrets.CACHE_ENDPOINT }}
+        port: 9000
+        bucket: actions-cache
+        insecure: true
+        accessKey: ${{ secrets.CACHE_ACCESS_KEY }}
+        secretKey: ${{ secrets.CACHE_SECRET_KEY }}
+        region: 'us-east-1'
+        use-fallback: false
+        path: ${{ inputs.build_dir }}
+        key: ${{ steps.validate.outputs.cache-key }}
 
     - name: Publish package to TestPyPI
       if: inputs.test && inputs.publish_on_pypi && inputs.python_package


### PR DESCRIPTION
## AI Summary

This pull request introduces several updates to the `.github/workflows/cd_release.yml` file, focusing on deprecating unnecessary inputs, enhancing caching and validation mechanisms, and replacing an external action with inline Git commands for better control. Below is a summary of the most important changes:

### Deprecation and Input Updates:
* Updated the `upload_distribution` input description to indicate that it no longer has any effect, as the source distribution is now always uploaded to the local cache. A warning is also issued if this input is used. [[1]](diffhunk://#diff-596559b1f8b64fb202104da87bab57ea30a0902451ca9cba6826485bf30976cdL120-R120) [[2]](diffhunk://#diff-596559b1f8b64fb202104da87bab57ea30a0902451ca9cba6826485bf30976cdR179-R230)

### Caching Enhancements:
* Added a new `outputs.cache-key` to store the cache key for the local cache where the source distribution is stored.
* Integrated a new "Setup local cache" step using the `tespkg/actions-cache` action to manage caching of the built source distribution.

### Validation Improvements:
* Introduced a "Validate source distribution" step to ensure the build directory exists and is not empty before proceeding with publishing. This replaces the previous upload artifact step.

### Git Workflow Refinement:
* Replaced the use of the `CasperWA/push-protected` action with inline Git commands for merging and pushing changes to the release branch. This change provides more control and transparency in the workflow.

These changes collectively improve the workflow's clarity, reliability, and maintainability.