### PR TITLE
Update permissions in local workflows

### DIFF
--- a/.github/workflows/_local_cd_release.yml
+++ b/.github/workflows/_local_cd_release.yml
@@ -10,6 +10,8 @@ jobs:
     name: Call reusable workflow
     if: github.repository == 'SINTEF/ci-cd' && startsWith(github.ref, 'refs/tags/v')
     uses: ./.github/workflows/cd_release.yml
+    permissions:
+      contents: write
     with:
       # General
       git_username: "TEAM 4.0[bot]"

--- a/.github/workflows/_local_ci_cd_updated_main.yml
+++ b/.github/workflows/_local_ci_cd_updated_main.yml
@@ -9,6 +9,8 @@ jobs:
     name: Call reusable workflow
     if: github.repository_owner == 'SINTEF'
     uses: ./.github/workflows/ci_cd_updated_default_branch.yml
+    permissions:
+      contents: write
     with:
       git_username: "TEAM 4.0[bot]"
       git_email: "TEAM4.0@SINTEF.no"


### PR DESCRIPTION
## AI Summary

This pull request updates the permissions for reusable workflows in the GitHub Actions configuration to ensure proper access rights. Specifically, it adds `contents: write` permissions to two workflows.

### Workflow permission updates:

* [`.github/workflows/_local_cd_release.yml`](diffhunk://#diff-fdd59c41178dd8e26bf9b67a99726030d1a0c46528295a26b607ad29917a9049R13-R14): Added `contents: write` permissions to the `Call reusable workflow` job to enable write access to repository contents during the release process.
* [`.github/workflows/_local_ci_cd_updated_main.yml`](diffhunk://#diff-171abb48eda5310804112a47108a8bb17b1c78967c4bb226df109e432b875dacR12-R13): Added `contents: write` permissions to the `Call reusable workflow` job to enable write access to repository contents during CI/CD operations on the default branch.